### PR TITLE
docs: update readme with new skill name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ All toolkits depend on `init` for shared rules, secrets handling, and the MCP se
 | `bootstrap` | Setup | `/init-workspace` | Checks for `uv`, Python venv, and `dlt`; installs what's missing; then runs `dlt ai init` and lists available toolkits | *"Run /init-workspace to set up a Python environment with dlt"* |
 | `rest-api-pipeline` | Build | `find-source` | Scaffold, debug, and validate REST API ingestion pipelines | *"Use find-source to load data from the Stripe API into DuckDB"* |
 | `dlthub-runtime` | Run | `setup-runtime` | Deploy pipelines to the dltHub platform | *"Use setup-runtime to deploy my pipeline to dltHub"* |
-| `data-exploration` | Explore | `connect-and-profile` | Query loaded data and create marimo dashboards | *"Use connect-and-profile to explore my Stripe pipeline and create a dashboard"* |
+| `data-exploration` | Explore | `explore-data` | Query loaded data and create marimo dashboards | *"Use explore-data to explore my Stripe pipeline and create a dashboard"* |
 
 > `init` is a shared dependency that provides rules, secrets handling, and the MCP server. It is installed automatically by `dlt ai init` or as a separate plugin via the Claude marketplace.
 


### PR DESCRIPTION
connect-and-profile --> explore-data as entry-point 