### PR TITLE
fix: toolkit connectivity — data gap handovers and adjust-endpoint next steps

### DIFF
--- a/workbench/data-exploration/rules/workflow.md
+++ b/workbench/data-exploration/rules/workflow.md
@@ -20,12 +20,12 @@ Infer intent from the user's message — never ask "do you have a specific quest
 
 ### Outgoing (from data-exploration)
 
-- **rest-api-pipeline** → `find-source` or `new-endpoint` — when `explore-data` identifies a data gap (needed columns don't exist in any table) and the user wants to extend the pipeline
+- **rest-api-pipeline** → `new-endpoint` (missing column/concept) or `adjust-endpoint` (data exists but looks truncated/stale) — when `explore-data` finds a data gap and the user wants to fix the pipeline
 - **dlthub-runtime** → `setup-runtime` — when the pipeline and notebook are production-ready and the user wants to deploy or schedule
 
 ### Incoming (to data-exploration)
 
-- From **rest-api-pipeline** (after `validate-data` or `view-data`) — pipeline name and dataset are already known. `explore-data` should skip `list_pipelines` discovery and go straight to `list_tables`.
+- From **rest-api-pipeline** (after `validate-data`, `view-data`, `new-endpoint`, or `adjust-endpoint`) — pipeline name and dataset are already known. `explore-data` should skip `list_pipelines` discovery and go straight to `list_tables`.
 - From transformation toolkit (after `validate-transformed-data` or `new-endpoint`) — pipeline name and transformed tables are already known. `explore-data` should skip `list_pipelines` discovery and go straight to `list_tables`.
 - From **dlthub-runtime** (marimo scheduled jobs) — a notebook already exists. `explore-data` picks up from the existing `analysis_plan.md` iteration path.
 

--- a/workbench/data-exploration/rules/workflow.md
+++ b/workbench/data-exploration/rules/workflow.md
@@ -20,7 +20,7 @@ Infer intent from the user's message — never ask "do you have a specific quest
 
 ### Outgoing (from data-exploration)
 
-- **rest-api-pipeline** → `new-endpoint` (missing column/concept) or `adjust-endpoint` (data exists but looks truncated/stale) — when `explore-data` finds a data gap and the user wants to fix the pipeline
+- **rest-api-pipeline** → `find-source` (new data source) or `new-endpoint` (missing column/concept) or `adjust-endpoint` (data exists but looks truncated/stale) — when `explore-data` finds a data gap and the user wants to extend or fix the pipeline
 - **dlthub-runtime** → `setup-runtime` — when the pipeline and notebook are production-ready and the user wants to deploy or schedule
 
 ### Incoming (to data-exploration)

--- a/workbench/data-exploration/skills/explore-data/SKILL.md
+++ b/workbench/data-exploration/skills/explore-data/SKILL.md
@@ -91,7 +91,7 @@ For the user's question (from argument or selection), decide:
 If the columns needed for the question don't exist in any table:
 - Tell the user: "The data doesn't have [missing column/concept]. You'd need to add this to your pipeline."
 - Record the gap in analysis_plan.md under `## Data Gaps`.
-- Suggest handoff to **rest-api-pipeline** toolkit if the user wants to extend the pipeline.
+- Suggest invoking `new-endpoint` (missing concept) or `adjust-endpoint` (data exists but looks truncated/stale) if the user wants to fix the pipeline.
 - Do not plan a chart for a question with missing data.
 
 ### Confirm the spec

--- a/workbench/data-exploration/skills/explore-data/SKILL.md
+++ b/workbench/data-exploration/skills/explore-data/SKILL.md
@@ -91,7 +91,7 @@ For the user's question (from argument or selection), decide:
 If the columns needed for the question don't exist in any table:
 - Tell the user: "The data doesn't have [missing column/concept]. You'd need to add this to your pipeline."
 - Record the gap in analysis_plan.md under `## Data Gaps`.
-- Suggest invoking `new-endpoint` (missing concept) or `adjust-endpoint` (data exists but looks truncated/stale) if the user wants to fix the pipeline.
+- Suggest handoff to **rest-api-pipeline** toolkit if the user wants to extend the pipeline.
 - Do not plan a chart for a question with missing data.
 
 ### Confirm the spec

--- a/workbench/rest-api-pipeline/skills/adjust-endpoint/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/adjust-endpoint/SKILL.md
@@ -21,3 +21,7 @@ Parse `$ARGUMENTS`:
 ### Real example: OpenAI Usage API
 
 Pipeline worked with `.add_limit(1)`. After removing the limit, it hung forever — dlt's auto-detected paginator looped. Fix: added explicit `"paginator": {"type": "cursor", "cursor_path": "next_page", "cursor_param": "page"}`. Full load then completed in 5 seconds.
+
+## Next steps
+
+- Full load complete → invoke `explore-data` to chart and analyze the data

--- a/workbench/rest-api-pipeline/skills/debug-pipeline/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/debug-pipeline/SKILL.md
@@ -160,6 +160,6 @@ Do NOT remove settings the user had before you started debugging.
 
 ## Next steps
 
-- **Load successful** → use `validate-data` to inspect schema and data
+- **Load successful** → use `validate-data` to inspect schema and data, or hand over to `explore-data` (data-exploration toolkit) to jump straight into charts and analysis
 - **Config/secrets missing** → check TOML sections, revisit `create-rest-api-pipeline` step 6b for credential setup
 - **No pipeline exists** → use `create-rest-api-pipeline` to scaffold one first


### PR DESCRIPTION
## Summary
- `data-exploration/rules/workflow.md`: replace vague `find-source or new-endpoint` with `new-endpoint` (missing concept) or `adjust-endpoint` (truncated/stale data); merge incoming rest-api-pipeline bullet to cover all four entry skills
- `explore-data/SKILL.md`: name exact skills (`new-endpoint` / `adjust-endpoint`) in data gap handoff instead of vague "rest-api-pipeline toolkit"
- `adjust-endpoint/SKILL.md`: add Next steps — suggest `explore-data` after a full load completes

