### PR TITLE
Making transformations SQL-first 

### DIFF
--- a/workbench/data-exploration/rules/workflow.md
+++ b/workbench/data-exploration/rules/workflow.md
@@ -21,6 +21,7 @@ Infer intent from the user's message — never ask "do you have a specific quest
 ### Outgoing (from data-exploration)
 
 - **rest-api-pipeline** → `find-source` (new data source) or `new-endpoint` (missing column/concept) or `adjust-endpoint` (data exists but looks truncated/stale) — when `explore-data` finds a data gap and the user wants to extend or fix the pipeline
+- **transformations** — when the user decides the raw tables need proper modeling before further analysis; pipeline name, dataset, and profiled table structure carry over to `annotate-sources`
 - **dlthub-runtime** → `setup-runtime` — when the pipeline and notebook are production-ready and the user wants to deploy or schedule
 
 ### Incoming (to data-exploration)

--- a/workbench/rest-api-pipeline/rules/workflow.md
+++ b/workbench/rest-api-pipeline/rules/workflow.md
@@ -20,4 +20,5 @@
 When the user's needs go beyond this toolkit, hand over to:
 
 - **data-exploration** — after `validate-data` or `view-data`, when the user wants interactive notebooks, charts, dashboards, or deeper analysis with marimo
+- **transformations** — after `validate-data` or `view-data`, when the user wants to model the ingested data into a CDM or run cross-source transformations
 - **dlthub-runtime** — when the pipeline is production-ready and the user wants to deploy, schedule, or run it on the dltHub platform

--- a/workbench/transformations/rules/workflow.md
+++ b/workbench/transformations/rules/workflow.md
@@ -7,7 +7,7 @@
 1. **Annotate sources** (`annotate-sources`) — verify pipelines exist, extract source schemas, derive canonical concepts from use cases, map tables to concepts, identify cross-source natural keys
 2. **Create ontology** (`create-ontology`) — build the entity graph: one entity per concept, union attributes from all contributing sources, define relationships from natural keys and FKs
 3. **Generate CDM** (`generate-cdm`) — apply Kimball dimensional modeling: classify fact/dimension, define grain, surrogate keys, SCD types, conformed dimensions
-4. **Create transformation** (`create-transformation`) — write `@dlt.hub.transformation` ibis functions that map source tables to CDM entities
+4. **Create transformation** (`create-transformation`) — write SQL-first `@dlt.hub.transformation` functions (with optional ibis) that map source tables to CDM entities
 
 ## Handover to other toolkits
 

--- a/workbench/transformations/rules/workflow.md
+++ b/workbench/transformations/rules/workflow.md
@@ -9,6 +9,11 @@
 3. **Generate CDM** (`generate-cdm`) — apply Kimball dimensional modeling: classify fact/dimension, define grain, surrogate keys, SCD types, conformed dimensions
 4. **Create transformation** (`create-transformation`) — write SQL-first `@dlt.hub.transformation` functions (with optional ibis) that map source tables to CDM entities
 
+## Incoming
+
+- From **rest-api-pipeline** (after `validate-data` or `view-data`) — pipeline name, destination, and dataset are already known. `annotate-sources` should skip `list_pipelines` discovery and go straight to schema extraction on the known pipeline. Business context may already be available from the ingestion session.
+- From **data-exploration** (after exploring raw pipeline data) — pipeline name, dataset, and table structure are already understood. The user has decided the raw tables need proper modeling before further analysis. `annotate-sources` can skip discovery and lean on the already-profiled table structure; natural key candidates and data quality observations from the exploration session should carry over — but always re-confirmed.
+
 ## Handover to other toolkits
 
 When the user's needs go beyond this toolkit, hand over to:

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -260,7 +260,7 @@ When to add `columns=`:
 
 Omitting `columns=` causes **silent data loss** — dlt strips the column from the outer SELECT if its schema entry has no `data_type`.
 
-**Do NOT use `execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
+**Do NOT use `mcp__dlt__execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
 
 ### 5. Write the script
 
@@ -323,32 +323,17 @@ import os
 os.chdir(Path(__file__).resolve().parents[1])  # run from project root
 ```
 
-**During development iterations, use `dev_mode=True`** — dlt drops and recreates the dataset on every run, so no load packages can get stuck between iterations:
-
-```python
-if __name__ == "__main__":
-    pipeline = dlt.pipeline(
-        pipeline_name="<business_domain>_pipeline",
-        destination="<destination>",
-        dataset_name="<business_domain>",
-        dev_mode=True,  # safe for iteration — remove before production
-    )
-```
-
-For pipeline traces, failed jobs, and load package inspection, use the `debug-pipeline` skill from the **rest-api-pipeline** toolkit.
-
-**When `dev_mode` is not suitable (production datasets or shared destinations):**
-
-If stale pending packages exist after a failed run, clear them before re-running:
+After changing SQL and before re-testing, clear stale pending packages if prior failed packages exist:
 
 ```
-# TODO: remove when dlt issue is resolved — drop-pending-packages is a workaround for stuck packages
 dlt pipeline <pipeline_name> drop-pending-packages
 ```
 
 Use `sync` and `drop-pending-packages` for different failure classes:
 - `dlt pipeline <pipeline_name> sync` — recover/refresh local pipeline state from destination state.
 - `dlt pipeline <pipeline_name> drop-pending-packages` — remove stale failed/pending load packages that can keep retrying old SQL and mask new fixes.
+
+If no recoverable destination state exists, `sync` may not resolve partial package retries; use `drop-pending-packages` before re-run.
 
 **If incorrect schema/tables were already loaded to destination, treat `drop` as last resort.**
 Use this escalation order:

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -323,9 +323,14 @@ import os
 os.chdir(Path(__file__).resolve().parents[1])  # run from project root
 ```
 
-After changing SQL and before re-testing, clear stale pending packages if prior failed packages exist:
+**During development iterations**, use the `debug-pipeline` skill from the **rest-api-pipeline** toolkit — it offers more help with failing pipelines, and particularly sets up `dev_mode=True` for development iterations.
+
+**When `dev_mode` is not suitable (production datasets or shared destinations):**
+
+If stale pending packages exist after a failed run, clear them before re-running:
 
 ```
+# TODO: remove when dlt issue is resolved — drop-pending-packages is a workaround for stuck packages
 dlt pipeline <pipeline_name> drop-pending-packages
 ```
 

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -86,6 +86,21 @@ Build an execution order:
 
 One `@dlt.hub.transformation` function per CDM entity. Wrap all in a `@dlt.source`.
 
+**Dataset binding is required when yielding from `@dlt.source`.**
+When a transformation resource is returned/yielded from a source, pass the dataset argument explicitly (for example `yield dim_person(source_dataset)`). Not binding datasets can raise `IncompatibleDatasetsException`.
+
+```python
+@dlt.source
+def hubspot_activity_schema(source_dataset: dlt.Dataset):
+    # Correct: dataset is explicitly bound
+    yield dim_company(source_dataset)
+    yield fact_activity(source_dataset)
+
+@dlt.hub.transformation
+def dim_company(dataset: dlt.Dataset):
+    yield dataset("SELECT company_id, name FROM hubspot__companies")
+```
+
 **Default to SQL transformation logic** — pass a SQL string directly to `dataset()` (https://dlthub.com/docs/hub/features/transformations#31-alternatively-use-pure-sql-for-the-transformation).
 Use SQL first because it is easier for users to review, generally more reliable for LLM generation, and dlt can transpile dialect differences when needed.
 
@@ -104,6 +119,24 @@ def dim_users(dataset: dlt.Dataset):
 ```
 
 Use `query_dialect` if your SQL dialect differs from the destination.
+
+**Cross-dataset SQL must use fully qualified source references.**
+When writing into `<target_dataset>` from a different source dataset, unqualified table names may resolve against the target dataset and fail with "table not found". For BigQuery, always use ``project.dataset.table`` for source-side refs.
+
+```python
+@dlt.hub.transformation
+def fact_activity(dataset: dlt.Dataset):
+    yield dataset(
+        """
+        SELECT a.id, a.activity_type, a.created_at
+        FROM `my_project.source_dataset_name.activities` AS a
+        """
+    )
+```
+
+**Association key check is mandatory before FK logic.**
+For nested association tables, verify join lineage first: association table `_dlt_parent_id` joins to parent row `_dlt_id` (not to parent business keys like `id`).
+Do this verification before writing any JOIN used to derive foreign keys.
 
 **ibis remains supported as an option** when SQL becomes too verbose for a specific step (complex programmatic expression building, reusable expression fragments, or existing ibis-heavy codebases). If ibis is chosen, keep everything lazy and never fall back to pandas.
 
@@ -261,6 +294,33 @@ Show a summary of:
 - Any source columns skipped and why
 
 Ask user to confirm before running the transformation.
+
+### 7. Run and recover safely
+
+Run the script from the project root so `.dlt` state resolves correctly. If needed, enforce root CWD in entrypoint:
+
+```python
+from pathlib import Path
+import os
+
+os.chdir(Path(__file__).resolve().parents[1])  # run from project root
+```
+
+After changing SQL and before re-testing, clear stale pending packages if prior failed packages exist:
+
+```
+dlt pipeline <pipeline_name> drop-pending-packages
+```
+
+Use `sync` and `drop-pending-packages` for different failure classes:
+- `dlt pipeline <pipeline_name> sync` — recover/refresh local pipeline state from destination state.
+- `dlt pipeline <pipeline_name> drop-pending-packages` — remove stale failed/pending load packages that can keep retrying old SQL and mask new fixes.
+
+If no recoverable destination state exists, `sync` may not resolve partial package retries; use `drop-pending-packages` before re-run.
+
+References:
+- CLI docs: https://dlthub.com/docs/reference/command-line-interface
+- Transformations docs: https://dlthub.com/docs/hub/features/transformations
 
 ## Output
 

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -56,14 +56,13 @@ Read in parallel:
 - `.schema/taxonomy.json` — table mappings and natural keys
 - `.schema/CDM.dbml` — CDM entity definitions and column specs
 
-### 2. Get actual source schema
+### 3. Get actual source schema
 
 Prefer relation schema from dlt dataset objects (not `get_table_schema` MCP tool) for actual column types.
 The MCP tool may include untyped/null-only columns that were never materialized in the destination.
 
 ```python
 import dlt
-import ibis
 
 pipeline = dlt.attach(pipeline_name="<pipeline_name>")
 dataset = pipeline.dataset()
@@ -71,9 +70,9 @@ relation = dataset.<table_name>
 schema = relation.schema()  # authoritative column list
 ```
 
-Cross-check the annotated columns in `annotated-sources.dbml` against the ibis schema. Note any discrepancies.
+Cross-check the annotated columns in `annotated-sources.dbml` against the schema from `relation.schema()`. Note any discrepancies.
 
-### 3. Plan transformation order
+### 4. Plan transformation order
 
 **Always run dimensions before facts** — facts join on dimension surrogate keys.
 
@@ -97,7 +96,7 @@ Pick one key type for this pipeline (`text` or `bigint`) and apply it consistent
 Do not mix key representations (`INT64` vs `STRING`) for related keys across dimensions/facts.
 If source systems disagree on key type, normalize to the chosen contract in staging/CTEs first.
 
-### 4. Write transformation functions
+### 5. Write transformation functions
 
 One `@dlt.hub.transformation` function per CDM entity. Wrap all in a `@dlt.source`.
 
@@ -191,7 +190,7 @@ def dim_person(dataset: dlt.Dataset):
     ...
 ```
 
-`columns=` `data_type` values for keys must match the key type contract selected in Step 3.
+`columns=` `data_type` values for keys must match the key type contract selected in Step 4.
 
 When to add `columns=`:
 - Any column from a LEFT JOIN (lookup may return NULL)
@@ -202,7 +201,7 @@ Omitting `columns=` causes **silent data loss** — dlt strips the column from t
 
 **Do NOT use `execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
 
-### 5. Write the script
+### 6. Write the script
 
 Output file: `transformations/<dataset_name>_to_cdm.py`
 
@@ -242,7 +241,7 @@ if __name__ == "__main__":
 
 Name the dataset after the grain of the star schema — what the data mart *is about*: `person_interactions`, `order_fulfillment`, `event_attendance`. Never use source system names (`hubspot_stripe_cdm`) or generic names (`combined_cdm`, `my_pipeline`). A good name tells an analyst what business process lives in the dataset without reading the code.
 
-### 6. Get feedback before running
+### 7. Get feedback before running
 
 Show a summary of:
 - Output tables being created
@@ -252,7 +251,7 @@ Show a summary of:
 
 Ask user to confirm before running the transformation.
 
-### 7. Run and recover safely
+### 8. Run and recover safely
 
 Run the script from the project root so `.dlt` state resolves correctly. If needed, enforce root CWD in entrypoint:
 

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -6,7 +6,7 @@ argument-hint: "[pipeline-name]"
 
 # Create transformation
 
-Write `@dlt.hub.transformation` functions that map annotated source tables to CDM entities using ibis.
+Write `@dlt.hub.transformation` functions that map annotated source tables to CDM entities, using SQL-first with optional ibis.
 
 **Requires:**
 - `.schema/<cdm-name>/taxonomy.json` — confirmed table→concept mappings and natural keys; read `_name` from this file to determine `<cdm-name>`
@@ -56,10 +56,10 @@ Read in parallel:
 - `.schema/taxonomy.json` — table mappings and natural keys
 - `.schema/CDM.dbml` — CDM entity definitions and column specs
 
-### 2. Get actual source schema via ibis
+### 2. Get actual source schema
 
-**Always use ibis (not `get_table_schema` MCP tool) for actual column types.**
-The MCP tool includes untyped/null-only columns that were never materialized in the destination — ibis reflects only what actually exists.
+Prefer relation schema from dlt dataset objects (not `get_table_schema` MCP tool) for actual column types.
+The MCP tool may include untyped/null-only columns that were never materialized in the destination.
 
 ```python
 import dlt
@@ -86,10 +86,8 @@ Build an execution order:
 
 One `@dlt.hub.transformation` function per CDM entity. Wrap all in a `@dlt.source`.
 
-**Use ibis for transformation logic — never pandas DataFrames.**
-ibis expressions are lazy, push computation to the source database, and compose cleanly across unions, joins, and window functions. Falling back to `.to_pandas()` for merges defeats this — keep everything in ibis until dlt loads the result.
-
-**Alternatively, pure SQL is supported** — pass a SQL string directly to `dataset()` instead of using ibis expressions (https://dlthub.com/docs/hub/features/transformations#31-alternatively-use-pure-sql-for-the-transformation). SQL can produce more predictable output schemas and may be preferable for simpler transformations or when the user is more comfortable with SQL:
+**Default to SQL transformation logic** — pass a SQL string directly to `dataset()` (https://dlthub.com/docs/hub/features/transformations#31-alternatively-use-pure-sql-for-the-transformation).
+Use SQL first because it is easier for users to review, generally more reliable for LLM generation, and dlt can transpile dialect differences when needed.
 
 ```python
 @dlt.hub.transformation
@@ -97,9 +95,39 @@ def dim_person(dataset: dlt.Dataset):
     yield dataset("SELECT email, first_name, last_name FROM hubspot__contacts ORDER BY email")
 ```
 
+If a relation variable is already available (for example `slack_dataset`), treat it as a callable dataset relation and pass SQL directly:
+
+```python
+@dlt.hub.transformation
+def dim_users(dataset: dlt.Dataset):
+    yield slack_dataset("SELECT user_id, email, created_at FROM users")
+```
+
 Use `query_dialect` if your SQL dialect differs from the destination.
 
-**ibis requires a SQL-capable destination** (BigQuery, Snowflake, DuckDB with file-based access, etc.). If the user requests DuckDB as destination, check whether ibis can connect to it in the context — if not, switch to BigQuery or another cloud destination and inform the user.
+**ibis remains supported as an option** when SQL becomes too verbose for a specific step (complex programmatic expression building, reusable expression fragments, or existing ibis-heavy codebases). If ibis is chosen, keep everything lazy and never fall back to pandas.
+
+Minimal ibis example (single-table transform), adapted from dlt docs:
+
+```python
+@dlt.hub.transformation
+def dim_person(dataset: dlt.Dataset):
+    contacts = dataset.table("hubspot__contacts").to_ibis()
+    yield contacts.select("email", "first_name", "last_name").order_by("email").limit(1000)
+```
+
+ibis join + aggregate example (useful for fact pre-aggregation):
+
+```python
+@dlt.hub.transformation
+def orders_per_user(dataset: dlt.Dataset):
+    purchases = dataset.table("purchases").to_ibis()
+    customers = dataset.table("customers").to_ibis()
+    enriched = purchases.join(customers, purchases.customer_id == customers.id)
+    yield enriched.group_by(customers.name).aggregate(order_count=purchases.id.count())
+```
+
+**ibis requires a SQL-capable destination** (BigQuery, Snowflake, DuckDB with file-based access, etc.). If the user requests DuckDB as destination, check whether ibis can connect to it in the context — if not, keep SQL-first transformations or switch to a destination that supports the desired ibis workflow.
 
 **Decorator (default pattern):**
 ```python
@@ -110,7 +138,9 @@ def dim_person(dataset: dlt.Dataset):
     ...
 ```
 
-**Cross-source transformations only** (data from multiple pipelines): ibis connections must be created **before** the CDM pipeline starts. Use module-level connection variables initialised in a setup function called before `pipeline.run()`:
+**Cross-source transformations:** use SQL-first where possible by selecting from available datasets in SQL; use ibis connections only when cross-dataset SQL composition is not practical in the current environment.
+
+If ibis is needed for cross-source composition, initialise connections **before** the CDM pipeline starts:
 
 ```python
 _AC = None
@@ -132,7 +162,7 @@ if __name__ == "__main__":
     pipeline.run(my_source())
 ```
 
-**ibis patterns:**
+**Optional ibis patterns (only when ibis path is selected):**
 
 Surrogate keys — use `.hash().cast("string")` (no `ibis.md5()`):
 ```python
@@ -180,7 +210,7 @@ When to add `columns=`:
 
 Omitting `columns=` causes **silent data loss** — dlt strips the column from the outer SELECT if its schema entry has no `data_type`.
 
-**Do NOT use `mcp__dlt__execute_sql_query` for cloud destinations** — use dlt + ibis directly.
+**Do NOT use `mcp__dlt__execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
 
 ### 5. Write the script
 
@@ -189,7 +219,6 @@ Output file: `transformations/<dataset_name>_to_cdm.py`
 Structure:
 ```python
 import dlt
-import ibis
 
 @dlt.source
 def <dataset_name>_to_cdm():

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -260,7 +260,7 @@ When to add `columns=`:
 
 Omitting `columns=` causes **silent data loss** — dlt strips the column from the outer SELECT if its schema entry has no `data_type`.
 
-**Do NOT use `mcp__dlt__execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
+**Do NOT use `execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
 
 ### 5. Write the script
 

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -164,16 +164,7 @@ def dim_person(dataset: dlt.Dataset):
     yield contacts.select("email", "first_name", "last_name").order_by("email").limit(1000)
 ```
 
-ibis join + aggregate example (useful for fact pre-aggregation):
-
-```python
-@dlt.hub.transformation
-def orders_per_user(dataset: dlt.Dataset):
-    purchases = dataset.table("purchases").to_ibis()
-    customers = dataset.table("customers").to_ibis()
-    enriched = purchases.join(customers, purchases.customer_id == customers.id)
-    yield enriched.group_by(customers.name).aggregate(order_count=purchases.id.count())
-```
+For more complex ibis patterns (joins, aggregations, unions, `row_number`, window functions, etc.) see the [ibis Table expression API](https://ibis-project.org/reference/expression-tables).
 
 **ibis requires a SQL-capable destination** (BigQuery, Snowflake, DuckDB with file-based access, etc.). If the user requests DuckDB as destination, check whether ibis can connect to it in the context — if not, keep SQL-first transformations or switch to a destination that supports the desired ibis workflow.
 
@@ -188,58 +179,7 @@ def dim_person(dataset: dlt.Dataset):
 
 **Cross-source transformations:** use SQL-first where possible by selecting from available datasets in SQL; use ibis connections only when cross-dataset SQL composition is not practical in the current environment.
 
-If ibis is needed for cross-source composition, initialise connections **before** the CDM pipeline starts:
-
-```python
-_AC = None
-_LUMA = None
-
-def _init_connections() -> None:
-    global _AC, _LUMA
-    _AC = dlt.pipeline("active_campaigns", destination="bigquery", dataset_name="active_campaigns").dataset().ibis()
-    _LUMA = dlt.pipeline("luma_events_data", destination="bigquery", dataset_name="luma_events_data").dataset().ibis()
-
-def dim_person():
-    contacts = _AC.table("contacts")
-    guests   = _LUMA.table("event_guests")
-    ...  # pure ibis — no .to_pandas()
-
-if __name__ == "__main__":
-    _init_connections()          # BEFORE pipeline is created
-    pipeline = dlt.pipeline(...)
-    pipeline.run(my_source())
-```
-
-**Optional ibis patterns (only when ibis path is selected):**
-
-Surrogate keys — use `.hash().cast("string")` (no `ibis.md5()`):
-```python
-person_sk = contacts.email.hash().cast("string").name("person_sk")
-```
-
-CASE WHEN — use `ibis.cases(...)` not `ibis.case()` (ibis 10+):
-```python
-ibis.cases((condition, value), else_=default)
-```
-
-First-row-per-group (dedup) — use `row_number()` over a window:
-```python
-import ibis.expr.types as ir
-row_num = ibis.row_number().over(ibis.window(group_by=["email"], order_by=[ibis.desc("updated_at")]))
-contacts.mutate(rn=row_num).filter(ibis._.rn == 0)
-```
-
-Join column references — always reference via original table variable after join (silent ambiguity otherwise):
-```python
-joined = contacts.join(companies, contacts.company_id == companies.id)
-# WRONG: joined.email  ← ambiguous if both tables have email
-# RIGHT: contacts.email  ← explicit
-```
-
-Cross-source union (from `taxonomy[concept].natural_key` + `taxonomy[concept].tables`):
-```python
-persons = hubspot_contacts.select(...).union(luma_guests.select(...))
-```
+If ibis is needed for cross-source composition, initialise connections **before** the CDM pipeline starts — see the [ibis Table expression API](https://ibis-project.org/reference/expression-tables) for join, union, and window function patterns.
 
 **`columns=` hint — REQUIRED for any column that may be NULL on first run:**
 ```python
@@ -277,7 +217,7 @@ def <dataset_name>_to_cdm(dataset: dlt.Dataset):
     yield dim_company(dataset)
     yield dim_event(dataset)
     # facts after
-    yield fact_event_attendance(dataset: dlt.Dataset)
+    yield fact_event_attendance(dataset)
 
 @dlt.hub.transformation(write_disposition="replace")
 def dim_person(dataset: dlt.Dataset):

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -260,7 +260,7 @@ When to add `columns=`:
 
 Omitting `columns=` causes **silent data loss** — dlt strips the column from the outer SELECT if its schema entry has no `data_type`.
 
-**Do NOT use `mcp__dlt__execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
+**Do NOT use `execute_sql_query` for cloud destinations** — use dlt transformations with SQL-first (or ibis when explicitly selected).
 
 ### 5. Write the script
 
@@ -323,17 +323,32 @@ import os
 os.chdir(Path(__file__).resolve().parents[1])  # run from project root
 ```
 
-After changing SQL and before re-testing, clear stale pending packages if prior failed packages exist:
+**During development iterations, use `dev_mode=True`** — dlt drops and recreates the dataset on every run, so no load packages can get stuck between iterations:
+
+```python
+if __name__ == "__main__":
+    pipeline = dlt.pipeline(
+        pipeline_name="<business_domain>_pipeline",
+        destination="<destination>",
+        dataset_name="<business_domain>",
+        dev_mode=True,  # safe for iteration — remove before production
+    )
+```
+
+For pipeline traces, failed jobs, and load package inspection, use the `debug-pipeline` skill from the **rest-api-pipeline** toolkit.
+
+**When `dev_mode` is not suitable (production datasets or shared destinations):**
+
+If stale pending packages exist after a failed run, clear them before re-running:
 
 ```
+# TODO: remove when dlt issue is resolved — drop-pending-packages is a workaround for stuck packages
 dlt pipeline <pipeline_name> drop-pending-packages
 ```
 
 Use `sync` and `drop-pending-packages` for different failure classes:
 - `dlt pipeline <pipeline_name> sync` — recover/refresh local pipeline state from destination state.
 - `dlt pipeline <pipeline_name> drop-pending-packages` — remove stale failed/pending load packages that can keep retrying old SQL and mask new fixes.
-
-If no recoverable destination state exists, `sync` may not resolve partial package retries; use `drop-pending-packages` before re-run.
 
 **If incorrect schema/tables were already loaded to destination, treat `drop` as last resort.**
 Use this escalation order:

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -115,7 +115,7 @@ If a relation variable is already available (for example `slack_dataset`), treat
 ```python
 @dlt.hub.transformation
 def dim_users(dataset: dlt.Dataset):
-    yield slack_dataset("SELECT user_id, email, created_at FROM users")
+    yield dataset("SELECT user_id, email, created_at FROM users")
 ```
 
 Use `query_dialect` if your SQL dialect differs from the destination.

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -82,6 +82,21 @@ Build an execution order:
 2. Non-conformed dimensions
 3. Fact tables (after all their dimension FKs exist)
 
+**Do not self-reference transformation outputs while building facts (default).**
+By default, fact SQL must be derived from source-side tables/logic (or explicit stage resources), not from newly produced `dim_*` output tables.
+This avoids cyclic/incompatible behavior across runs and destinations.
+
+Allowed exception:
+- If the user explicitly requests output-to-output dependencies and the destination semantics are confirmed to support that pattern, document it in the plan before writing SQL.
+
+**Define a key type contract before writing any SQL.**
+Pick one key type for this pipeline (`text` or `bigint`) and apply it consistently to:
+- all surrogate/foreign key casts in SQL or ibis
+- every corresponding `columns=` schema hint
+
+Do not mix key representations (`INT64` vs `STRING`) for related keys across dimensions/facts.
+If source systems disagree on key type, normalize to the chosen contract in staging/CTEs first.
+
 ### 4. Write transformation functions
 
 One `@dlt.hub.transformation` function per CDM entity. Wrap all in a `@dlt.source`.
@@ -236,6 +251,8 @@ def dim_person(dataset: dlt.Dataset):
     ...
 ```
 
+`columns=` `data_type` values for keys must match the key type contract selected in Step 3.
+
 When to add `columns=`:
 - Any column from a LEFT JOIN (lookup may return NULL)
 - Any cast from string to typed value where source may be empty
@@ -254,13 +271,13 @@ Structure:
 import dlt
 
 @dlt.source
-def <dataset_name>_to_cdm():
+def <dataset_name>_to_cdm(dataset: dlt.Dataset):
     # dimensions first
-    yield dim_person
-    yield dim_company
-    yield dim_event
+    yield dim_person(dataset)
+    yield dim_company(dataset)
+    yield dim_event(dataset)
     # facts after
-    yield fact_event_attendance
+    yield fact_event_attendance(dataset: dlt.Dataset)
 
 @dlt.hub.transformation(write_disposition="replace")
 def dim_person(dataset: dlt.Dataset):
@@ -318,8 +335,23 @@ Use `sync` and `drop-pending-packages` for different failure classes:
 
 If no recoverable destination state exists, `sync` may not resolve partial package retries; use `drop-pending-packages` before re-run.
 
+**If incorrect schema/tables were already loaded to destination, treat `drop` as last resort.**
+Use this escalation order:
+1. Inspect first: `dlt pipeline <pipeline_name> failed-jobs` and `dlt pipeline <pipeline_name> trace`
+2. Clear stale retries: `dlt pipeline <pipeline_name> drop-pending-packages`
+3. Reconcile local state: `dlt pipeline <pipeline_name> sync`
+4. Only then consider selective drop: `dlt pipeline <pipeline_name> drop <resource>` (or `--drop-all` only with explicit user confirmation)
+
+Safety rules for `drop`:
+- Prefer dropping specific resources over `--drop-all`
+- Confirm pipeline name, destination, dataset, and selected resources before accepting the prompt
+- Explain that drop removes destination tables and resets matching state; this can force full reloads and may remove good data with bad data
+- If uncertain which resources are safe to drop, stop and ask the user before executing
+- After drop, re-run transformations and validate schema/tables before further loads
+
 References:
 - CLI docs: https://dlthub.com/docs/reference/command-line-interface
+- `dlt pipeline drop`: https://dlthub.com/docs/reference/command-line-interface#dlt-pipeline-drop
 - Transformations docs: https://dlthub.com/docs/hub/features/transformations
 
 ## Output

--- a/workbench/transformations/skills/create-transformation/SKILL.md
+++ b/workbench/transformations/skills/create-transformation/SKILL.md
@@ -23,7 +23,21 @@ Parse `$ARGUMENTS`:
 
 ## Steps
 
-### 1. Install dlt[hub]
+### 1. Install dependencies
+
+**Determine destination** — if the destination is not already known from prior context (prior conversation), ask the user which destination they are using before proceeding.
+
+Install the matching ibis backend:
+
+| Destination    | Command                              |
+|----------------|--------------------------------------|
+| DuckDB         | `uv add "ibis-framework[duckdb]"`    |
+| PostgreSQL     | `uv add "ibis-framework[postgres]"`  |
+| Snowflake      | `uv add "ibis-framework[snowflake]"` |
+| BigQuery       | `uv add "ibis-framework[bigquery]"`  |
+| *Some backend* | `uv add ibis-framework[<backend>]`     |
+
+Then install dlt[hub]:
 
 ```
 uv add "dlt[hub]"


### PR DESCRIPTION
Ibis requires too many rounds of corrections, and is taking longer to build a skill for - meanwhile the previously deployed  `create-transformations` skill is not something that would get successfully compiled even after various rounds of the LLM trying. This is the feedback from most testers. I wanted to implement a quick fix for people who may already be using this, since it has been launched and also will be part of our education soon.

The rationale for going SQL first (for now): both people and LLMs have seen more SQL than ibis, so is easier to get the script to be writte, compiled and reviewed. 

Cons: It's still more token intensive than ibis (but still much faster to solution) 

Furthermore this skill now also includes some retry logic, since the LLM tries to run the transformation then fix its bugs but by that time some bad load packages get stuck. 