### PR TITLE
[rest-api-pipeline] Rate limits handling

### DIFF
--- a/workbench/rest-api-pipeline/skills/adjust-endpoint/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/adjust-endpoint/SKILL.md
@@ -22,6 +22,40 @@ Parse `$ARGUMENTS`:
 
 Pipeline worked with `.add_limit(1)`. After removing the limit, it hung forever — dlt's auto-detected paginator looped. Fix: added explicit `"paginator": {"type": "cursor", "cursor_path": "next_page", "cursor_param": "page"}`. Full load then completed in 5 seconds.
 
+## Harden optional endpoints with response_actions
+
+Some endpoints return 404 or an error body for certain parent items (e.g. a repo with no issues, an org with no members). In production this kills the pipeline. Fix with `response_actions` — no custom Python needed. See `new-endpoint` step 3A for syntax and examples.
+
+## Enable parallelization for dependent resources
+
+If the pipeline has child resources (transformer pattern, e.g. comments per post), add `parallelized: True` to fetch child pages concurrently. Caveat: all child pages for one parent are buffered in memory — skip for parents with very large child sets. See `new-endpoint` step 3A for syntax and the memory caveat.
+
+## Configure retry settings for rate-limited APIs
+
+dlt automatically retries HTTP 429 (Too Many Requests) and respects `Retry-After` response headers. The defaults (5 retries, 60s timeout) work for most APIs. For APIs with strict per-minute limits or high request volume, tune in `.dlt/config.toml`:
+
+```toml
+[runtime]
+request_max_attempts = 10    # retries per request (default: 5)
+request_backoff_factor = 1.5 # steeper backoff so waits grow longer (default: 1)
+```
+
+**Per-second vs per-minute limits**: if the API sends `Retry-After` headers, dlt uses those values directly — the backoff config is irrelevant. If it doesn't, raise `request_backoff_factor` so the wait grows with each retry and the window has time to reset.
+
+### Slow or heavy responses: increase request_timeout
+
+`request_timeout` (default: 60s) is how long dlt waits for a single HTTP response. Raise it when:
+- The API generates a report or aggregation server-side before responding (e.g. analytics export endpoints)
+- The endpoint returns large payloads that take time to stream (e.g. bulk export, wide date ranges)
+- You see `requests.exceptions.ReadTimeout` or `ConnectionTimeout` in the trace
+
+```toml
+[runtime]
+request_timeout = 120   # or higher — match the API's documented response time SLA
+```
+
+Ref: https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/advanced.md
+
 ## Next steps
 
 *If a quick-start path is active, follow that path's sequence instead — this list is for standalone use.*

--- a/workbench/rest-api-pipeline/skills/create-rest-api-pipeline/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/create-rest-api-pipeline/SKILL.md
@@ -153,6 +153,8 @@ access_token = "ak-*******-cae"
 
 For more complex credential setup (research where to get keys, multiple providers), use `setup-secrets` skill.
 
+**Rate limits**: dlt handles HTTP 429 and `Retry-After` automatically — no custom retry code needed. For strict rate-limited APIs, tune retry settings in `adjust-endpoint`.
+
 **ALWAYS Get Feedback** before you run the pipeline for a first time. Show summary of files that you changed or generated.
 
 ### 7. Debug pipeline - first run

--- a/workbench/rest-api-pipeline/skills/debug-pipeline/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/debug-pipeline/SKILL.md
@@ -72,10 +72,18 @@ A pipeline that runs for a long time is suspicious but MAY be normal (large data
 - `OffsetPaginator`/`PageNumberPaginator` without `stop_after_empty_page=True` require `total_path` or `maximum_offset`/`maximum_page`, otherwise they loop forever.
 - `JSONResponseCursorPaginator` with wrong `cursor_path` → cursor never advances → infinite loop.
 
-**Silent retries look like a hang** — the pipeline may be retrying failed HTTP requests:
-- Default: 5 retries with exponential backoff (up to 16s per attempt), 60s request timeout.
-- A single failing endpoint can stall for 60-80+ seconds before raising an error.
-- Override in `.dlt/config.toml` for faster failure during debugging:
+**Silent retries look like a hang / HTTP 429 rate limits** — the pipeline may be retrying failed HTTP requests:
+- dlt **automatically retries HTTP 429 (Too Many Requests)** and respects `Retry-After` response headers — no custom retry code needed.
+- Default retry config: 5 attempts, exponential backoff (factor=1, max delay=300s), 60s timeout.
+- A 429 with a long `Retry-After` header can stall the pipeline for minutes — this is normal behaviour.
+- If the pipeline keeps hitting 429 even after retries, the API has strict rate limits. Tune in `.dlt/config.toml`:
+  ```toml
+  [runtime]
+  request_max_attempts = 10    # more retries (default: 5)
+  request_backoff_factor = 1.5 # steeper backoff so waits grow longer (default: 1)
+  ```
+  Do NOT lower `request_max_retry_delay` for rate limits — longer delays let the rate-limit window reset.
+- For faster failure **during debugging**, reduce retries instead:
   ```toml
   [runtime]
   request_timeout = 15

--- a/workbench/rest-api-pipeline/skills/debug-pipeline/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/debug-pipeline/SKILL.md
@@ -91,7 +91,9 @@ A pipeline that runs for a long time is suspicious but MAY be normal (large data
   ```
 - Ref: https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/advanced.md (timeouts and retries)
 
-**Working but slow** — each request returns new data and URL changes. Use `.add_limit(N)` to cap pages during development.
+### Pipeline runs slower than expected
+
+Each request returns new data and URL changes — this is a large dataset, not a hang. Use `.add_limit(N)` to cap pages during development. For rate-limit-induced slowdowns (429 + `Retry-After` stalls), see **Silent retries / HTTP 429 rate limits** above.
 
 **Can't tell which resource is stuck** in a multi-resource pipeline — switch to sequential extraction:
 ```toml

--- a/workbench/rest-api-pipeline/skills/new-endpoint/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/new-endpoint/SKILL.md
@@ -38,6 +38,7 @@ Note what patterns the existing resources use:
 - Response structure (nested objects, arrays)
 - Pagination (same as existing endpoints or different?)
 - Any special headers or auth requirements
+- **Rate limits**: requests-per-second or per-minute limits for this endpoint (may differ from other endpoints)
 
 **Read dlt docs** if you need to refresh on config options:
 - REST API source: `https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/basic.md`
@@ -54,6 +55,44 @@ If the endpoint fits the existing client config (base_url, auth, paginator), add
 - **data_selector**: match the response structure
 - **Pagination**: inherits from `client.paginator` — override per-resource if different
 - **processing_steps**: add `map`/`filter`/`yield_map` if needed (e.g., `Decimal` for money — NEVER `float`)
+
+**`response_actions`** — handle specific HTTP responses declaratively, without custom Python:
+
+```python
+{
+    "name": "org_members",
+    "endpoint": {
+        "path": "orgs/{org}/members",
+        "response_actions": [
+            {"status_code": 404, "action": "ignore"},          # org has no members — skip silently
+            {"content": "Not Found", "action": "ignore"},      # match response body substring
+            {"status_code": 200, "content": "error", "action": "ignore"},  # AND condition
+            set_encoding,                                       # callable — applied to every response
+        ],
+    },
+}
+```
+
+Use `"ignore"` for optional endpoints that return 404 for some parent items (e.g. repos with no issues). Use a callable to fix encoding, add/remove fields, or patch malformed responses before dlt parses them. **Never write a `processing_steps` workaround for something `response_actions` handles.** Ref: https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/advanced.md
+
+**`parallelized`** — concurrent child-resource fetching for dependent resources:
+
+```python
+{
+    "resources": [
+        "posts",
+        {
+            "name": "post_comments",
+            "parallelized": True,          # fetch comments for all posts concurrently
+            "endpoint": {
+                "path": "posts/{resources.posts.id}/comments",
+            },
+        },
+    ],
+}
+```
+
+Use when the resource is a child of another (transformer pattern) and each parent has many independent child records. **Caveat**: all child pages for one parent are buffered in memory before yielding — avoid for parents with very large child sets. Ref: https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/advanced.md
 
 #### B. Custom @dlt.resource — when declarative doesn't fit
 
@@ -106,6 +145,7 @@ Check if the existing pipeline uses patterns that the new resource should also a
 - **Write disposition**: is `merge` used with `primary_key`? Should the new resource also merge?
 - **Processing steps**: are there shared transformations (e.g., Decimal conversion for money fields)?
 - **Column hints**: do existing resources define `columns` for nullable fields?
+- **Rate limits**: does this endpoint have tighter rate limits than existing ones? If so, check `.dlt/config.toml` `[runtime]` retry settings — dlt handles 429 automatically but defaults (5 retries, 60s timeout) may need tuning. See `adjust-endpoint` for the config block.
 
 Flag any gaps to the user — the new resource works now but may need these patterns for production use.
 

--- a/workbench/rest-api-pipeline/skills/new-endpoint/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/new-endpoint/SKILL.md
@@ -56,7 +56,7 @@ If the endpoint fits the existing client config (base_url, auth, paginator), add
 - **Pagination**: inherits from `client.paginator` — override per-resource if different
 - **processing_steps**: add `map`/`filter`/`yield_map` if needed (e.g., `Decimal` for money — NEVER `float`)
 
-**`response_actions`** — handle specific HTTP responses declaratively, without custom Python:
+##### Prevent optional endpoints from failing the pipeline with `response_actions`
 
 ```python
 {
@@ -75,7 +75,7 @@ If the endpoint fits the existing client config (base_url, auth, paginator), add
 
 Use `"ignore"` for optional endpoints that return 404 for some parent items (e.g. repos with no issues). Use a callable to fix encoding, add/remove fields, or patch malformed responses before dlt parses them. **Never write a `processing_steps` workaround for something `response_actions` handles.** Ref: https://dlthub.com/docs/dlt-ecosystem/verified-sources/rest_api/advanced.md
 
-**`parallelized`** — concurrent child-resource fetching for dependent resources:
+##### Fetch child resources concurrently with `parallelized`
 
 ```python
 {

--- a/workbench/rest-api-pipeline/skills/view-data/SKILL.md
+++ b/workbench/rest-api-pipeline/skills/view-data/SKILL.md
@@ -25,7 +25,7 @@ This opens a browser with table schemas, row counts, and sample data.
 
 **Essential Reading:**
 - `https://dlthub.com/docs/general-usage/dataset-access/dataset.md`
-- `https://dlthub.com/docs/general-usage/dataset-access/ibis-backend.md`
+- `https://dlthub.com/docs/general-usage/dataset-access/dataset#ibis`
 
 Use `pipeline.dataset()` to access loaded data. This is **destination agnostic** — works the same on duckdb, postgres, bigquery, etc. NEVER import destination libraries (like `duckdb`) directly.
 

--- a/workbench/sql-database-pipeline/skills/view-data/SKILL.md
+++ b/workbench/sql-database-pipeline/skills/view-data/SKILL.md
@@ -25,7 +25,7 @@ This opens a browser with table schemas, row counts, and sample data.
 
 **Essential Reading:**
 - `https://dlthub.com/docs/general-usage/dataset-access/dataset.md`
-- `https://dlthub.com/docs/general-usage/dataset-access/ibis-backend.md`
+- `https://dlthub.com/docs/general-usage/dataset-access/dataset#ibis`
 
 Use `pipeline.dataset()` to access loaded data. This is **destination agnostic** — works the same on duckdb, postgres, bigquery, etc. NEVER import destination libraries (like `duckdb`) directly.
 


### PR DESCRIPTION
Cover rate limits and key REST API edge cases in rest-api-pipeline skills
  
Documents dlt's built-in handling of HTTP 429 / Retry-After and adds guidance on response_actions (ignore 404s on optional endpoints, transform responses) and parallelized (concurrent child-resource fetching) 

+ fix link to datasets#ibis

resolves [#148](https://github.com/dlt-hub/product_backlog/issues/148)