### PR TITLE
Cross-agent trigger-eval runners (Codex + Cursor)

### DIFF
--- a/.claude/skills/create-eval/SKILL.md
+++ b/.claude/skills/create-eval/SKILL.md
@@ -94,7 +94,11 @@ Run:
 uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill>
 ```
 
-This creates all workspaces defined in config.json.
+This creates all workspaces defined in config.json (default agent: claude). To also test Codex/Cursor, build for those agents too (they get a `--<agent>` workspace suffix so all three coexist):
+```bash
+uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill> --agent codex
+uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill> --agent cursor
+```
 
 ## Step 7: Continue to run-eval
 

--- a/.claude/skills/run-eval/SKILL.md
+++ b/.claude/skills/run-eval/SKILL.md
@@ -18,9 +18,9 @@ stat -c %Y workbench/<toolkit>/skills/<skill>/SKILL.md
 stat -c %Y evals/.evals/<workspace>/.claude/skills/<skill>/SKILL.md
 ```
 
-If the source is newer (or workspace doesn't exist), rebuild:
+If the source is newer (or workspace doesn't exist), rebuild (add `--agent <agent>` to match the agent you'll eval; non-claude workspaces live at `…--<agent>/` with skills under `.cursor/skills` or `.agents/skills`):
 ```bash
-uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill>
+uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill> [--agent <agent>]
 ```
 
 ## Step 1: Run the eval
@@ -35,6 +35,8 @@ uv run python tools/run_trigger_eval.py evals/<toolkit>/<skill> --verbose [--mod
 # Single workspace
 uv run python tools/run_trigger_eval.py evals/<toolkit>/<skill> --workspace <ws-id> --verbose [--model <model>]
 ```
+
+By default the eval runs on Claude. To run on another agent (or all), pass `--agent` — `claude` (default), `cursor`, `codex`, or `all` / a comma-list like `codex,cursor`. Non-Claude agents need their CLI installed + authenticated (`codex`; `cursor-agent login` or `CURSOR_API_KEY`) and the workspace built for that agent (Step 0, same `--agent`). `--agent all` reports per-agent results in one run. Note: always-loaded router skills (e.g. `dlthub-router`) are N/A on Codex — measure routers on Claude/Cursor; see EVALS.md.
 
 ## Step 2: Read the results
 

--- a/EVALS.md
+++ b/EVALS.md
@@ -23,7 +23,21 @@ Each eval can define **multiple workspaces** with different toolkit combinations
 
 ### Isolation
 
-Eval workspaces are self-contained — `claude -p` runs from the workspace directory and only sees the skills installed there. This prevents pollution from the dev project's plugins, skills, and commands.
+Eval workspaces are self-contained — the agent runner (`claude -p`, `codex exec`, or `cursor-agent -p`) runs from the workspace directory and only sees the skills installed there. This prevents pollution from the dev project's plugins, skills, and commands.
+
+### Agents (Claude, Codex, Cursor)
+
+Evals run on all three agents via `--agent {claude,cursor,codex}` (or `--agent all`). Each agent signals a skill trigger differently, so the runner detects it differently:
+
+| Agent | Headless driver | Trigger signal |
+|---|---|---|
+| Claude | `claude -p --output-format stream-json` | first `Skill` tool_use in the stream |
+| Codex | `codex exec --json -s read-only` | a shell command reading `.agents/skills/<name>/SKILL.md`, excluding always-on `AGENTS.md` skills |
+| Cursor | `cursor-agent -p --output-format stream-json --trust` | a `readToolCall` on `.cursor/skills/<name>/SKILL.md` |
+
+Codex and Cursor have no native `Skill` tool — they "activate" a skill by **reading its `SKILL.md`**. **Always-loaded router skills (e.g. `dlthub-router`) are N/A on Codex**: there the routing index lives in the always-loaded `AGENTS.md`, not a skill activation, so there is no discrete trigger event to measure. Opt-in skills (e.g. `find-source`) are measured normally on all three.
+
+Codex and Cursor require their CLIs installed and authenticated (`codex`; and `cursor-agent login` or `CURSOR_API_KEY`).
 
 ### Clashes
 
@@ -53,10 +67,10 @@ evals/
       trigger-eval.json    # Queries with expected outcomes
       README.md            # Notes, findings, known issues (optional)
   .evals/                  # Generated workspaces (gitignored)
-    <toolkit>--<skill>--<workspace-id>/
+    <toolkit>--<skill>--<workspace-id>[--<agent>]/   # --<agent> suffix for cursor/codex; claude unsuffixed
       .venv/
-      .claude/skills/...
-      .claude/rules/...
+      .claude/skills/...   # claude; cursor -> .cursor/skills, codex -> .agents/skills
+      .claude/rules/...    # claude; cursor -> .cursor/rules/*.mdc, codex -> folded into AGENTS.md
 ```
 
 ### config.json
@@ -96,8 +110,11 @@ Array of queries with expected trigger behavior:
 ### Create workspaces
 
 ```bash
-# Builds all workspaces defined in config.json
+# Builds all workspaces defined in config.json (default agent: claude)
 uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill>
+
+# Build for a specific agent (cursor/codex get a --<agent> workspace suffix)
+uv run python tools/create_eval_workspace.py evals/<toolkit>/<skill> --agent codex
 ```
 
 ### Run eval
@@ -114,6 +131,12 @@ uv run python tools/run_trigger_eval.py evals/<toolkit>/<skill> --model claude-s
 
 # Multiple runs for reliability
 uv run python tools/run_trigger_eval.py evals/<toolkit>/<skill> --runs-per-query 3 --verbose
+
+# A specific non-Claude agent (CLI must be installed + authenticated)
+uv run python tools/run_trigger_eval.py evals/<toolkit>/<skill> --agent codex --verbose
+
+# All agents in one run — reports per-agent results (requires each agent's workspace built)
+uv run python tools/run_trigger_eval.py evals/<toolkit>/<skill> --agent all --verbose
 ```
 
 ### Run eval with analysis

--- a/evals/init/dlthub-router/README.md
+++ b/evals/init/dlthub-router/README.md
@@ -6,9 +6,9 @@ The `dlthub-router` skill must trigger and route correctly on **all three agents
 
 **What is validated automatically vs. manually today:**
 
-- **Automated trigger eval (Claude only):** the harness below drives the agent headlessly via `claude -p`. There is no equivalent headless driver wired for Cursor or Codex yet, so automated trigger-rate measurement currently runs on Claude only.
+- **Automated trigger eval (all three agents):** the harness below drives each agent headlessly — `claude -p`, `codex exec --json`, `cursor-agent -p` — via `tools/run_trigger_eval.py --agent {claude,cursor,codex}` (or `--agent all`). Claude triggers are detected via the `Skill` tool; Codex/Cursor via a read of the skill's `SKILL.md`. See [EVALS.md](../../../EVALS.md).
 - **Cross-agent install + always-loaded surface (all three):** verified via `dlthub ai toolkit install … --strict` for `--agent claude|cursor|codex` and by inspecting the generated rule / `.mdc` / `AGENTS.md` (the index reaches the always-loaded surface on each).
-- **Cursor/Codex trigger automation is a follow-up** — needs headless runners for those agents. Until then, trigger behavior on Cursor/Codex is checked manually.
+- **`dlthub-router` is N/A for automated trigger measurement on Codex:** it's an always-loaded router, and on Codex the routing index lives in `AGENTS.md` (not a skill activation), so there's no discrete trigger event. (It also currently exceeds Codex's 1024-char skill-description cap and is dropped as a skill — tracked in [#75](https://github.com/dlt-hub/dlthub-ai-workbench-internal/issues/75).) Measure it on Claude/Cursor; on Codex, confirm routing in the final answer manually.
 
 ## Status: eval framework bug — skill triggers correctly
 
@@ -37,13 +37,16 @@ CLAUDECODE= claude -p "how can I build my first pipeline?" --output-format strea
 
 Check the stream for `{"name":"Skill","input":{"skill":"dlthub-router"}}`.
 
-### How to check (Cursor / Codex, manual until runners exist)
+### How to check (Cursor / Codex, automated)
 
-Create the workspace for the target agent and open it in that agent, then issue the same prompts and confirm the skill triggers and routes:
+Build the workspace for the target agent and run the eval against it:
 
 ```bash
-# (agent param support tracked as follow-up; today the workspace installs for --agent claude)
+uv run python tools/create_eval_workspace.py evals/init/dlthub-router --agent cursor
+uv run python tools/run_trigger_eval.py evals/init/dlthub-router --agent cursor --verbose
 ```
+
+On **Cursor**, `dlthub-router` installs as a skill and triggers via a `readToolCall` on `.cursor/skills/dlthub-router/SKILL.md`. On **Codex** the router is N/A for automated measurement (see above) — routing is served by the always-loaded `AGENTS.md`; confirm it manually by checking the final answer names the right toolkit.
 
 ### Negative cases (100% precision in automated eval)
 

--- a/tools/create_eval_workspace.py
+++ b/tools/create_eval_workspace.py
@@ -18,6 +18,7 @@ config.json format:
 Each workspace is always recreated from scratch.
 """
 
+import argparse
 import json
 import shutil
 import subprocess
@@ -52,13 +53,23 @@ def get_dlt_version() -> str:
     raise RuntimeError("Cannot detect dlt version from current environment")
 
 
-def ws_name_for(eval_dir: Path, workspace_id: str) -> str:
-    """Build workspace directory name: toolkit--skill--workspace_id."""
+def ws_name_for(eval_dir: Path, workspace_id: str, agent: str = "claude") -> str:
+    """Build workspace directory name: toolkit--skill--workspace_id[--agent].
+
+    The agent suffix is omitted for claude so existing claude workspace paths
+    (and run_trigger_eval.py's matching convention) stay unchanged; cursor/codex
+    get a suffix so all three agents can coexist for the same eval.
+    """
     rel = eval_dir.relative_to(ROOT / "evals")
-    return str(rel).replace("/", "--").replace("\\", "--") + "--" + workspace_id
+    name = str(rel).replace("/", "--").replace("\\", "--") + "--" + workspace_id
+    if agent != "claude":
+        name += "--" + agent
+    return name
 
 
-def create_single_workspace(workspace: Path, dlt_pkg: str, toolkits: list[str]) -> Path:
+def create_single_workspace(
+    workspace: Path, dlt_pkg: str, toolkits: list[str], agent: str = "claude"
+) -> Path:
     """Create a single eval workspace."""
     if workspace.exists():
         shutil.rmtree(workspace)
@@ -96,7 +107,7 @@ def create_single_workspace(workspace: Path, dlt_pkg: str, toolkits: list[str]) 
             "ai",
             "init",
             "--agent",
-            "claude",
+            agent,
             "--location",
             str(ROOT),
         ],
@@ -108,7 +119,7 @@ def create_single_workspace(workspace: Path, dlt_pkg: str, toolkits: list[str]) 
     # (`ai toolkit <name> install`) and rejects install-first, so fall back to it —
     # mirroring the dlthub->dlt CLI fallback above.
     base = ["uv", "run", cli, "--non-interactive", "ai", "toolkit"]
-    tail = ["--agent", "claude", "--location", str(ROOT)]
+    tail = ["--agent", agent, "--location", str(ROOT)]
     for toolkit in toolkits:
         print(f"  Installing toolkit: {toolkit}")
         result = run(base + ["install", toolkit] + tail, cwd=workspace, check=False)
@@ -119,21 +130,30 @@ def create_single_workspace(workspace: Path, dlt_pkg: str, toolkits: list[str]) 
     return workspace
 
 
-def report_workspace(workspace: Path) -> None:
-    """Print workspace contents."""
-    skills_dir = workspace / ".claude" / "skills"
+def report_workspace(workspace: Path, agent: str = "claude") -> None:
+    """Print workspace contents for the agent's install layout."""
+    # Skills land under a per-agent root: .claude/.cursor/.agents.
+    skills_root = {"claude": ".claude", "cursor": ".cursor", "codex": ".agents"}[agent]
+    skills_dir = workspace / skills_root / "skills"
     if skills_dir.is_dir():
         skills = [d.name for d in sorted(skills_dir.iterdir()) if d.is_dir()]
         print(f"  skills: {', '.join(skills) if skills else '(none)'}")
 
-    rules_dir = workspace / ".claude" / "rules"
+    # Rules: claude .claude/rules/*.md, cursor .cursor/rules/*.mdc; on codex
+    # rules are folded into the always-loaded AGENTS.md (no rules dir).
+    if agent == "codex":
+        agents_md = workspace / "AGENTS.md"
+        print(f"  AGENTS.md: {'present' if agents_md.is_file() else '(missing)'}")
+        return
+    rules_dir = workspace / skills_root / "rules"
+    rule_suffix = ".mdc" if agent == "cursor" else ".md"
     if rules_dir.is_dir():
-        rules = [f.name for f in sorted(rules_dir.iterdir()) if f.suffix == ".md"]
+        rules = [f.name for f in sorted(rules_dir.iterdir()) if f.suffix == rule_suffix]
         print(f"  rules:  {', '.join(rules) if rules else '(none)'}")
 
 
-def create_workspaces(eval_dir: Path) -> list[Path]:
-    """Create all workspaces defined in config.json."""
+def create_workspaces(eval_dir: Path, agent: str = "claude") -> list[Path]:
+    """Create all workspaces defined in config.json for the given agent."""
     config_path = eval_dir / "config.json"
     if not config_path.exists():
         print(f"ERROR: {config_path} not found")
@@ -155,28 +175,37 @@ def create_workspaces(eval_dir: Path) -> list[Path]:
     created = []
     for ws_id, ws_config in workspaces_config.items():
         toolkits = ws_config.get("toolkits", [])
-        name = ws_name_for(eval_dir, ws_id)
+        name = ws_name_for(eval_dir, ws_id, agent)
         workspace = EVALS_DIR / name
 
-        print(f"\n=== Workspace: {ws_id} ===")
+        print(f"\n=== Workspace: {ws_id} (agent={agent}) ===")
         print(f"  path: {workspace}")
         print(f"  dlt: {dlt_pkg}")
         print(f"  toolkits: {toolkits or '(init only)'}")
 
-        create_single_workspace(workspace, dlt_pkg, toolkits)
-        report_workspace(workspace)
+        create_single_workspace(workspace, dlt_pkg, toolkits, agent)
+        report_workspace(workspace, agent)
         created.append(workspace)
 
     return created
 
 
 def main():
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <eval-dir>")
-        print(f"  e.g.: {sys.argv[0]} evals/init/dlthub-router")
-        sys.exit(1)
+    parser = argparse.ArgumentParser(
+        description="Create eval workspaces for trigger testing."
+    )
+    parser.add_argument(
+        "eval_dir", help="Eval directory, e.g. evals/init/dlthub-router"
+    )
+    parser.add_argument(
+        "--agent",
+        default="claude",
+        choices=["claude", "cursor", "codex"],
+        help="Agent to initialize the workspaces for (default: claude)",
+    )
+    args = parser.parse_args()
 
-    eval_dir = Path(sys.argv[1])
+    eval_dir = Path(args.eval_dir)
     if not eval_dir.is_absolute():
         eval_dir = ROOT / eval_dir
 
@@ -184,8 +213,8 @@ def main():
         print(f"ERROR: {eval_dir} is not a directory")
         sys.exit(1)
 
-    workspaces = create_workspaces(eval_dir)
-    print(f"\n{len(workspaces)} workspace(s) created:")
+    workspaces = create_workspaces(eval_dir, args.agent)
+    print(f"\n{len(workspaces)} workspace(s) created (agent={args.agent}):")
     for ws in workspaces:
         print(f"  {ws}")
 

--- a/tools/run_trigger_eval.py
+++ b/tools/run_trigger_eval.py
@@ -255,27 +255,14 @@ def _codex_line_skill(line: str, baseline: set[str]) -> str | None:
     return None
 
 
-def _run_codex(
-    query: str,
-    workspace: str,
-    timeout: int,
-    model: str | None = None,
-) -> str | None:
-    """Run a query via `codex exec --json`. Return the skill that triggered, or None.
+def _stream_scan_for_skill(cmd, workspace, timeout, line_skill):
+    """Run cmd in the workspace, stream stdout JSONL, and return the first
+    non-None result of line_skill(line) — i.e. the first detected skill.
 
-    Codex has no native Skill tool: it "activates" a skill by running a shell
-    command that reads `.agents/skills/<name>/SKILL.md`. Always-on skills (the
-    AGENTS.md "ALWAYS ACTIVATE" bullets) are read every turn, so we exclude them
-    and return the first *opt-in* skill whose SKILL.md the query caused to be
-    read. stdin must be closed (DEVNULL) or codex blocks waiting on it; we run
-    read-only so the probe cannot mutate the workspace.
+    Shared by the codex and cursor runners (both have no native Skill tool and
+    signal a trigger by reading a SKILL.md). stdin is closed (codex blocks
+    otherwise); stderr is discarded.
     """
-    baseline = _codex_baseline_skills(workspace)
-
-    cmd = ["codex", "exec", query, "--json", "-s", "read-only"]
-    if model:
-        cmd.extend(["-m", model])
-
     process = subprocess.Popen(
         cmd,
         stdin=subprocess.DEVNULL,
@@ -302,7 +289,7 @@ def _run_codex(
             buffer += chunk.decode("utf-8", errors="replace")
             while "\n" in buffer:
                 line, buffer = buffer.split("\n", 1)
-                skill = _codex_line_skill(line, baseline)
+                skill = line_skill(line)
                 if skill:
                     return skill
     finally:
@@ -312,10 +299,55 @@ def _run_codex(
 
     # Drain any remaining buffered lines after process exit.
     for line in buffer.split("\n"):
-        skill = _codex_line_skill(line, baseline)
+        skill = line_skill(line)
         if skill:
             return skill
     return None
+
+
+def _run_codex(
+    query: str,
+    workspace: str,
+    timeout: int,
+    model: str | None = None,
+) -> str | None:
+    """Run a query via `codex exec --json`. Return the skill that triggered, or None.
+
+    Codex has no native Skill tool: it "activates" a skill by running a shell
+    command that reads `.agents/skills/<name>/SKILL.md`. Always-on skills (the
+    AGENTS.md "ALWAYS ACTIVATE" bullets) are read every turn, so we exclude them
+    and return the first *opt-in* skill whose SKILL.md the query caused to be
+    read. Runs read-only so the probe cannot mutate the workspace.
+    """
+    baseline = _codex_baseline_skills(workspace)
+    cmd = ["codex", "exec", query, "--json", "-s", "read-only"]
+    if model:
+        cmd.extend(["-m", model])
+    return _stream_scan_for_skill(
+        cmd, workspace, timeout, lambda line: _codex_line_skill(line, baseline)
+    )
+
+
+_CURSOR_SKILL_READ_RE = re.compile(r"\.cursor/skills/([a-z0-9][a-z0-9-]*)/SKILL\.md")
+
+
+def _cursor_line_skill(line: str) -> str | None:
+    """If a JSONL line is a readToolCall on an in-workspace SKILL.md, return that skill."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if event.get("type") != "tool_call":
+        return None
+    read_call = event.get("tool_call", {}).get("readToolCall")
+    if not read_call:
+        return None
+    path = read_call.get("args", {}).get("path", "")
+    m = _CURSOR_SKILL_READ_RE.search(path)
+    return m.group(1) if m else None
 
 
 def _run_cursor(
@@ -324,8 +356,21 @@ def _run_cursor(
     timeout: int,
     model: str | None = None,
 ) -> str | None:
-    """Cursor runner — implemented in T6 (Stage 2)."""
-    raise NotImplementedError("Cursor runner lands in T6")
+    """Run a query via `cursor-agent -p --output-format stream-json`. Return the
+    skill that triggered, or None.
+
+    Cursor has no native Skill tool: it activates a skill by reading the file via
+    a `readToolCall` on `.cursor/skills/<name>/SKILL.md`. Return the first such
+    in-workspace read. No baseline exclusion: cursor keeps always-on content as
+    auto-applied `.mdc` rules, not skill reads; the `.cursor/skills/` path
+    requirement excludes stray SKILL.md reads elsewhere in the repo. `--trust`
+    runs headlessly (auth via `cursor-agent login` or CURSOR_API_KEY) and lets
+    file reads through while rejecting shell/web — enough to detect the trigger.
+    """
+    cmd = ["cursor-agent", "-p", query, "--output-format", "stream-json", "--trust"]
+    if model:
+        cmd.extend(["--model", model])
+    return _stream_scan_for_skill(cmd, workspace, timeout, _cursor_line_skill)
 
 
 def run_eval_on_workspace(

--- a/tools/run_trigger_eval.py
+++ b/tools/run_trigger_eval.py
@@ -19,6 +19,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import select
 import subprocess
 import sys
@@ -44,15 +45,22 @@ def load_config(eval_dir: Path) -> dict[str, dict]:
     return workspaces
 
 
-def find_workspace(eval_dir: Path, ws_id: str) -> Path:
-    """Find workspace path for a given workspace ID."""
+def find_workspace(eval_dir: Path, ws_id: str, agent: str = "claude") -> Path:
+    """Find workspace path for a given workspace ID and agent.
+
+    Mirrors create_eval_workspace.ws_name_for: claude paths are unsuffixed;
+    cursor/codex get a `--<agent>` suffix so all three coexist.
+    """
     rel = eval_dir.relative_to(ROOT / "evals")
     name = str(rel).replace("/", "--").replace("\\", "--") + "--" + ws_id
+    if agent != "claude":
+        name += "--" + agent
     ws = EVALS_DIR / name
     if not ws.is_dir():
         print(f"ERROR: Workspace not found: {ws}", file=sys.stderr)
         print(
-            f"Run: uv run python tools/create_eval_workspace.py {eval_dir.relative_to(ROOT)}",
+            f"Run: uv run python tools/create_eval_workspace.py "
+            f"{eval_dir.relative_to(ROOT)} --agent {agent}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -63,9 +71,35 @@ def run_single_query(
     query: str,
     workspace: str,
     timeout: int,
+    agent: str = "claude",
     model: str | None = None,
 ) -> str | None:
-    """Run a query via claude -p. Return the skill name that triggered, or None."""
+    """Run one query and return the skill name that triggered, or None.
+
+    Dispatches to a per-agent runner. Each agent signals a skill trigger
+    differently (see the per-agent functions), but they share the return
+    contract: the name of the skill that triggered for this query, or None.
+    """
+    if agent == "claude":
+        return _run_claude(query, workspace, timeout, model)
+    if agent == "codex":
+        return _run_codex(query, workspace, timeout, model)
+    if agent == "cursor":
+        return _run_cursor(query, workspace, timeout, model)
+    raise ValueError(f"Unknown agent: {agent}")
+
+
+def _run_claude(
+    query: str,
+    workspace: str,
+    timeout: int,
+    model: str | None = None,
+) -> str | None:
+    """Run a query via claude -p. Return the skill name that triggered, or None.
+
+    Claude exposes skills as a native `Skill` tool, so a trigger is the first
+    tool_use in the stream being `Skill` (its `input.skill` is the name).
+    """
     cmd = [
         "claude",
         "-p",
@@ -176,10 +210,122 @@ def _extract_skill_name(json_fragment: str) -> str | None:
         return data.get("skill")
     except json.JSONDecodeError:
         # Partial JSON — look for "skill":"<name>" pattern
-        import re
-
         m = re.search(r'"skill"\s*:\s*"([^"]+)"', json_fragment)
         return m.group(1) if m else None
+
+
+_SKILL_READ_RE = re.compile(r"\.agents/skills/([a-z0-9][a-z0-9-]*)/SKILL\.md")
+
+
+def _codex_baseline_skills(workspace: str) -> set[str]:
+    """Always-on skills registered in the workspace AGENTS.md.
+
+    On Codex these are read on every turn regardless of the query (the
+    "ALWAYS ACTIVATE" bullets, written as `- ``<name>```), so they must be
+    excluded when detecting which skill a query actually triggered.
+    """
+    agents_md = Path(workspace) / "AGENTS.md"
+    if not agents_md.is_file():
+        return set()
+    names = set()
+    for line in agents_md.read_text().splitlines():
+        m = re.match(r"\s*-\s*`([a-z0-9][a-z0-9-]*)`", line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
+def _codex_line_skill(line: str, baseline: set[str]) -> str | None:
+    """If a JSONL line is a command reading a non-baseline SKILL.md, return that skill."""
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if event.get("type") not in ("item.started", "item.completed"):
+        return None
+    item = event.get("item", {})
+    if item.get("type") != "command_execution":
+        return None
+    for name in _SKILL_READ_RE.findall(item.get("command", "")):
+        if name not in baseline:
+            return name
+    return None
+
+
+def _run_codex(
+    query: str,
+    workspace: str,
+    timeout: int,
+    model: str | None = None,
+) -> str | None:
+    """Run a query via `codex exec --json`. Return the skill that triggered, or None.
+
+    Codex has no native Skill tool: it "activates" a skill by running a shell
+    command that reads `.agents/skills/<name>/SKILL.md`. Always-on skills (the
+    AGENTS.md "ALWAYS ACTIVATE" bullets) are read every turn, so we exclude them
+    and return the first *opt-in* skill whose SKILL.md the query caused to be
+    read. stdin must be closed (DEVNULL) or codex blocks waiting on it; we run
+    read-only so the probe cannot mutate the workspace.
+    """
+    baseline = _codex_baseline_skills(workspace)
+
+    cmd = ["codex", "exec", query, "--json", "-s", "read-only"]
+    if model:
+        cmd.extend(["-m", model])
+
+    process = subprocess.Popen(
+        cmd,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        cwd=workspace,
+    )
+
+    start_time = time.time()
+    buffer = ""
+    try:
+        while time.time() - start_time < timeout:
+            if process.poll() is not None:
+                remaining = process.stdout.read()
+                if remaining:
+                    buffer += remaining.decode("utf-8", errors="replace")
+                break
+            ready, _, _ = select.select([process.stdout], [], [], 1.0)
+            if not ready:
+                continue
+            chunk = os.read(process.stdout.fileno(), 8192)
+            if not chunk:
+                break
+            buffer += chunk.decode("utf-8", errors="replace")
+            while "\n" in buffer:
+                line, buffer = buffer.split("\n", 1)
+                skill = _codex_line_skill(line, baseline)
+                if skill:
+                    return skill
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait()
+
+    # Drain any remaining buffered lines after process exit.
+    for line in buffer.split("\n"):
+        skill = _codex_line_skill(line, baseline)
+        if skill:
+            return skill
+    return None
+
+
+def _run_cursor(
+    query: str,
+    workspace: str,
+    timeout: int,
+    model: str | None = None,
+) -> str | None:
+    """Cursor runner — implemented in T6 (Stage 2)."""
+    raise NotImplementedError("Cursor runner lands in T6")
 
 
 def run_eval_on_workspace(
@@ -191,6 +337,7 @@ def run_eval_on_workspace(
     timeout: int,
     runs_per_query: int,
     trigger_threshold: float,
+    agent: str,
     model: str | None,
     verbose: bool,
 ) -> dict:
@@ -205,6 +352,7 @@ def run_eval_on_workspace(
                     item["query"],
                     str(workspace),
                     timeout,
+                    agent,
                     model,
                 )
                 future_to_info[future] = (item, run_idx)
@@ -288,6 +436,7 @@ def run_eval_on_workspace(
     return {
         "workspace": ws_id,
         "workspace_path": str(workspace),
+        "agent": agent,
         "skill_name": skill_name,
         "results": results,
         "summary": {
@@ -327,6 +476,12 @@ def main():
         help="Trigger rate threshold (default: 0.5)",
     )
     parser.add_argument("--model", default=None, help="Model override")
+    parser.add_argument(
+        "--agent",
+        default="claude",
+        choices=["claude", "cursor", "codex"],
+        help="Agent to drive headlessly (default: claude)",
+    )
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
 
@@ -360,18 +515,24 @@ def main():
             reason = e.get("reason", "no reason")
             print(f"  - {e['query'][:60]}... ({reason})", file=sys.stderr)
 
+    skills_root = {"claude": ".claude", "cursor": ".cursor", "codex": ".agents"}[args.agent]
+
     all_results = []
     for ws_id in ws_configs:
-        workspace = find_workspace(eval_dir, ws_id)
+        workspace = find_workspace(eval_dir, ws_id, args.agent)
 
-        # Verify skill exists
-        skill_dir = workspace / ".claude" / "skills" / skill_name
+        # Verify skill exists in the agent's install layout
+        skill_dir = workspace / skills_root / "skills" / skill_name
         if not skill_dir.is_dir():
-            print(f"ERROR: Skill '{skill_name}' not in workspace '{ws_id}'", file=sys.stderr)
+            print(
+                f"ERROR: Skill '{skill_name}' not in workspace '{ws_id}' "
+                f"(agent={args.agent}, looked in {skills_root}/skills)",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
         if args.verbose:
-            print(f"\n=== Workspace: {ws_id} ({workspace}) ===", file=sys.stderr)
+            print(f"\n=== Workspace: {ws_id} ({workspace}) [agent={args.agent}] ===", file=sys.stderr)
             print(f"Skill: {skill_name}", file=sys.stderr)
             print(f"Queries: {len(eval_set)} ({args.runs_per_query} runs each)", file=sys.stderr)
 
@@ -384,6 +545,7 @@ def main():
             timeout=args.timeout,
             runs_per_query=args.runs_per_query,
             trigger_threshold=args.trigger_threshold,
+            agent=args.agent,
             model=args.model,
             verbose=args.verbose,
         )

--- a/tools/run_trigger_eval.py
+++ b/tools/run_trigger_eval.py
@@ -495,6 +495,35 @@ def run_eval_on_workspace(
     }
 
 
+VALID_AGENTS = ["claude", "cursor", "codex"]
+
+
+def parse_agents(spec: str) -> list[str]:
+    """Parse a --agent spec ('all', 'codex', or 'codex,cursor') into a list.
+
+    Raises ValueError on an unknown agent name.
+    """
+    agents = VALID_AGENTS[:] if spec == "all" else [a.strip() for a in spec.split(",") if a.strip()]
+    bad = [a for a in agents if a not in VALID_AGENTS]
+    if bad:
+        raise ValueError(
+            f"unknown agent(s): {', '.join(bad)} (valid: {', '.join(VALID_AGENTS)} or 'all')"
+        )
+    return agents
+
+
+def per_agent_rollup(all_results: list[dict]) -> list[dict]:
+    """Aggregate a flat list of per-(agent,workspace) results into per-agent totals."""
+    rollup: dict[str, dict] = {}
+    for r in all_results:
+        a = r["agent"]
+        agg = rollup.setdefault(a, {"agent": a, "total": 0, "passed": 0, "clashes": 0})
+        agg["total"] += r["summary"]["total"]
+        agg["passed"] += r["summary"]["passed"]
+        agg["clashes"] += r["summary"]["clashes"]
+    return list(rollup.values())
+
+
 def main():
     parser = argparse.ArgumentParser(description="Run trigger evaluation for a skill")
     parser.add_argument("eval_dir", help="Path to eval directory (e.g. evals/init/dlthub-router)")
@@ -524,8 +553,11 @@ def main():
     parser.add_argument(
         "--agent",
         default="claude",
-        choices=["claude", "cursor", "codex"],
-        help="Agent to drive headlessly (default: claude)",
+        help=(
+            "Agent(s) to drive headlessly: claude|cursor|codex, 'all', or a "
+            "comma-separated list (e.g. codex,cursor). One run reports per-agent "
+            "results. Default: claude."
+        ),
     )
     parser.add_argument("--verbose", action="store_true", help="Print progress to stderr")
     args = parser.parse_args()
@@ -560,60 +592,81 @@ def main():
             reason = e.get("reason", "no reason")
             print(f"  - {e['query'][:60]}... ({reason})", file=sys.stderr)
 
-    skills_root = {"claude": ".claude", "cursor": ".cursor", "codex": ".agents"}[args.agent]
+    try:
+        agents = parse_agents(args.agent)
+    except ValueError as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    roots = {"claude": ".claude", "cursor": ".cursor", "codex": ".agents"}
 
     all_results = []
-    for ws_id in ws_configs:
-        workspace = find_workspace(eval_dir, ws_id, args.agent)
+    for agent in agents:
+        skills_root = roots[agent]
+        for ws_id in ws_configs:
+            workspace = find_workspace(eval_dir, ws_id, agent)
 
-        # Verify skill exists in the agent's install layout
-        skill_dir = workspace / skills_root / "skills" / skill_name
-        if not skill_dir.is_dir():
-            print(
-                f"ERROR: Skill '{skill_name}' not in workspace '{ws_id}' "
-                f"(agent={args.agent}, looked in {skills_root}/skills)",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-
-        if args.verbose:
-            print(f"\n=== Workspace: {ws_id} ({workspace}) [agent={args.agent}] ===", file=sys.stderr)
-            print(f"Skill: {skill_name}", file=sys.stderr)
-            print(f"Queries: {len(eval_set)} ({args.runs_per_query} runs each)", file=sys.stderr)
-
-        output = run_eval_on_workspace(
-            eval_set=eval_set,
-            skill_name=skill_name,
-            workspace=workspace,
-            ws_id=ws_id,
-            num_workers=args.num_workers,
-            timeout=args.timeout,
-            runs_per_query=args.runs_per_query,
-            trigger_threshold=args.trigger_threshold,
-            agent=args.agent,
-            model=args.model,
-            verbose=args.verbose,
-        )
-
-        if args.verbose:
-            s = output["summary"]
-            print(
-                f"Results: {s['passed']}/{s['total']} passed  "
-                f"precision={s['precision']}  recall={s['recall']}  "
-                f"clashes={s['clashes']}",
-                file=sys.stderr,
-            )
-            for r in output["results"]:
-                status = "PASS" if r["pass"] else "FAIL"
-                rate_str = f"{r['triggers']}/{r['runs']}"
-                clash_str = f" CLASH→{r['clashes']}" if r.get("clashes") else ""
+            # Verify skill exists in the agent's install layout
+            skill_dir = workspace / skills_root / "skills" / skill_name
+            if not skill_dir.is_dir():
                 print(
-                    f"  [{status}] rate={rate_str} expected={r['should_trigger']}{clash_str}: "
-                    f"{r['query'][:80]}",
+                    f"ERROR: Skill '{skill_name}' not in workspace '{ws_id}' "
+                    f"(agent={agent}, looked in {skills_root}/skills)",
                     file=sys.stderr,
                 )
+                sys.exit(1)
 
-        all_results.append(output)
+            if args.verbose:
+                print(
+                    f"\n=== Workspace: {ws_id} ({workspace}) [agent={agent}] ===",
+                    file=sys.stderr,
+                )
+                print(f"Skill: {skill_name}", file=sys.stderr)
+                print(f"Queries: {len(eval_set)} ({args.runs_per_query} runs each)", file=sys.stderr)
+
+            output = run_eval_on_workspace(
+                eval_set=eval_set,
+                skill_name=skill_name,
+                workspace=workspace,
+                ws_id=ws_id,
+                num_workers=args.num_workers,
+                timeout=args.timeout,
+                runs_per_query=args.runs_per_query,
+                trigger_threshold=args.trigger_threshold,
+                agent=agent,
+                model=args.model,
+                verbose=args.verbose,
+            )
+
+            if args.verbose:
+                s = output["summary"]
+                print(
+                    f"Results: {s['passed']}/{s['total']} passed  "
+                    f"precision={s['precision']}  recall={s['recall']}  "
+                    f"clashes={s['clashes']}",
+                    file=sys.stderr,
+                )
+                for r in output["results"]:
+                    status = "PASS" if r["pass"] else "FAIL"
+                    rate_str = f"{r['triggers']}/{r['runs']}"
+                    clash_str = f" CLASH→{r['clashes']}" if r.get("clashes") else ""
+                    print(
+                        f"  [{status}] rate={rate_str} expected={r['should_trigger']}{clash_str}: "
+                        f"{r['query'][:80]}",
+                        file=sys.stderr,
+                    )
+
+            all_results.append(output)
+
+    # Per-agent rollup when more than one agent ran in this invocation.
+    if args.verbose and len(agents) > 1:
+        print("\n=== Per-agent summary ===", file=sys.stderr)
+        for agg in per_agent_rollup(all_results):
+            print(
+                f"  {agg['agent']:7} {agg['passed']}/{agg['total']} passed  "
+                f"clashes={agg['clashes']}",
+                file=sys.stderr,
+            )
 
     print(json.dumps(all_results if len(all_results) > 1 else all_results[0], indent=2))
 


### PR DESCRIPTION
Implements dlt-hub/dlthub-ai-workbench-internal#73 (parts 1–3): headless trigger-eval runners for **Codex** and **Cursor**, so trigger-rate / clash numbers are measured on all three agents, not just Claude.

## What changed
- `tools/create_eval_workspace.py`: `--agent {claude,cursor,codex}` (was hardcoded to claude). Non-claude workspaces get a `--<agent>` dir suffix so all three coexist; claude paths unchanged. `report_workspace` is agent-aware.
- `tools/run_trigger_eval.py`: `run_single_query` dispatches per-agent —
  - **Claude**: `claude -p --output-format stream-json` → first `Skill` tool_use (unchanged)
  - **Codex**: `codex exec --json -s read-only` → first non-baseline `.agents/skills/<name>/SKILL.md` read (baseline = AGENTS.md always-activate bullets)
  - **Cursor**: `cursor-agent -p --output-format stream-json --trust` → first `readToolCall` on `.cursor/skills/<name>/SKILL.md`
  - shared `_stream_scan_for_skill` helper for codex/cursor; `--agent all` / comma-list → one run reports per-agent results (`parse_agents`, `per_agent_rollup`).
- Docs: EVALS.md cross-agent section (per-agent driver + trigger-signal table), `--agent` usage in create-eval/run-eval skills, refreshed dlthub-router eval README.

## Verification
- `find-source` eval (opt-in skill) on **codex** and **cursor**: **20/20, precision 1.0, recall 1.0, 0 clashes** each (`--runs-per-query 1`).
- `make validate-toolkits` passes.

## Notes
- **`dlthub-router` is N/A for automated trigger measurement on Codex**: it's an always-loaded router (index lives in `AGENTS.md`, not a skill activation), and it also exceeds Codex's 1024-char skill-description cap and is dropped as a skill — filed separately as dlt-hub/dlthub-ai-workbench-internal#75.
- Cursor/Codex runs require their CLIs installed + authenticated (`codex`; `cursor-agent login` or `CURSOR_API_KEY`).
- Pre-existing (out of scope): eval workspaces are nested inside the repo, so codex/cursor can grep the whole repo; detection guards against this via the agent-specific skill path. Possible follow-up: build workspaces outside the repo tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
